### PR TITLE
Fix: CORS withCredentials true 설정

### DIFF
--- a/src/main/java/com/ixxp/culpop/config/WebSecurityConfig.java
+++ b/src/main/java/com/ixxp/culpop/config/WebSecurityConfig.java
@@ -63,6 +63,7 @@ public class WebSecurityConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD")
                 .allowedOrigins("http://localhost:8080", "http://localhost:5173", "http://43.202.13.38:8081/", "https://www.culpop.shop", "https://culpop.vercel.app")
+                .allowCredentials(true)
                 .exposedHeaders("Authorization", "RefreshToken");
     }
 }


### PR DESCRIPTION
CORS Access-Control-Allow-Credentials 에러 발생해서 해결하기 위해 .allowCredentials(true) 설정 추가
allowCredentials(true) 이거는 쿠키로 토큰을 보내려면 설정해줘야 함!